### PR TITLE
Preventing addListener from raising memory leak warnings.

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -54,10 +54,7 @@ var mkdir = function(affixes, callback) {
   var dirPath = generateName(affixes, 'd-');
   fs.mkdir(dirPath, 0700, function(err) { 
     if (!err) {
-      process.addListener('exit', function() {
-        try { fs.rmdirSync(dirPath); }
-        catch (rmErr) { /* removed normally */ }
-      } );
+      _gc.push(['rmdirSync', dirPath]);
     }
     if (callback)
       callback(err, dirPath);
@@ -66,10 +63,7 @@ var mkdir = function(affixes, callback) {
 var mkdirSync = function(affixes) {
   var dirPath = generateName(affixes, 'd-');
   fs.mkdirSync(dirPath, 0700);
-  process.addListener('exit', function() {
-    try { fs.rmdirSync(dirPath) }
-    catch (rmErr) { /* removed manually */ }
-  } );
+  _gc.push(['rmdirSync', dirPath]);
   return dirPath;
 }
 
@@ -79,10 +73,7 @@ var open = function(affixes, callback) {
   var filePath = generateName(affixes, 'f-')
   fs.open(filePath, 'w+', 0600, function(err, fd) {
     if (!err)
-      process.addListener('exit', function() {
-        try { fs.unlinkSync(filePath); }
-        catch (rmErr) { /* removed normally */ } 
-      });
+      _gc.push(['unlinkSync', filePath]);
     if (callback)
       callback(err, {path: filePath, fd: fd});
   });
@@ -91,13 +82,20 @@ var open = function(affixes, callback) {
 var openSync = function(affixes) {
   var filePath = generateName(affixes, 'f-')
   var fd = fs.openSync(filePath, "w+", 0600);
-  process.addListener('exit', function() {
-    try { fs.unlinkSync(filePath); }
-    catch (rmErr) { /* removed manually */ }
-  });
+  _gc.push(['unlinkSync', filePath]);
   return {path: filePath, fd: fd};
 }
-  
+
+/* GARBAGE COLLECTION ON EXIT */
+
+var _gc = [];
+process.addListener('exit', function() {
+  for(var i in _gc) {
+    try {
+      fs[_gc[i][0]](_gc[i][1]);
+    } catch (rmErr) { /* removed manually */ }
+  }
+});
 
 /* EXPORTS */
 


### PR DESCRIPTION
Unifying process exit event listening to avoid memory leak warnings.

Closes https://github.com/bruce/node-temp/issues/1
