### PR TITLE
Use single exit callback

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -93,12 +93,9 @@ var deleteAllTempFiles = function() {
 
 var mkdir = function(affixes, callback) {
   var dirPath = generateName(affixes, 'd-');
-  fs.mkdir(dirPath, 0700, function(err) { 
+  fs.mkdir(dirPath, 0700, function(err) {
     if (!err) {
-      process.addListener('exit', function() {
-        try { fs.rmdirSync(dirPath); }
-        catch (rmErr) { /* removed normally */ }
-      } );
+      deleteDirOnExit(dirPath);
     }
     if (callback)
       callback(err, dirPath);
@@ -107,10 +104,7 @@ var mkdir = function(affixes, callback) {
 var mkdirSync = function(affixes) {
   var dirPath = generateName(affixes, 'd-');
   fs.mkdirSync(dirPath, 0700);
-  process.addListener('exit', function() {
-    try { fs.rmdirSync(dirPath) }
-    catch (rmErr) { /* removed manually */ }
-  } );
+  deleteDirOnExit(dirPath);
   return dirPath;
 }
 
@@ -120,25 +114,19 @@ var open = function(affixes, callback) {
   var filePath = generateName(affixes, 'f-')
   fs.open(filePath, 'w+', 0600, function(err, fd) {
     if (!err)
-      process.addListener('exit', function() {
-        try { fs.unlinkSync(filePath); }
-        catch (rmErr) { /* removed normally */ } 
-      });
+      deleteFileOnExit(filePath);
     if (callback)
       callback(err, {path: filePath, fd: fd});
   });
 }
-                    
+
 var openSync = function(affixes) {
   var filePath = generateName(affixes, 'f-')
   var fd = fs.openSync(filePath, "w+", 0600);
-  process.addListener('exit', function() {
-    try { fs.unlinkSync(filePath); }
-    catch (rmErr) { /* removed manually */ }
-  });
+  deleteFileOnExit(filePath);
   return {path: filePath, fd: fd};
 }
-  
+
 
 /* EXPORTS */
 

--- a/test/temp-test.js
+++ b/test/temp-test.js
@@ -41,6 +41,11 @@ temp.open('bar', function(err, info) {
   util.log("open " + openPath);
 });
 
+for (var i=0; i <= 10; i++) {
+  temp.openSync();
+};
+assert.equal(process.listeners('exit').length, 1, 'temp created more than one listener for exit');
+
 process.addListener('exit', function() {
   assert.ok(mkdirFired, "temp.mkdir callback did not fire");
   assert.ok(openFired, "temp.open callback did not fire");


### PR DESCRIPTION
This diff solves the same problem that bermi addressed https://github.com/bruce/node-temp/pull/3, which is that if you create more than 10 temp files or dirs, you get the following warning:

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace: 
    at EventEmitter.<anonymous> (events.js:133:17)
    at EventEmitter.<anonymous> (node.js:383:29)
    at /Users/ryangreenberg/workspace/node-temp/lib/temp.js:73:13
    at /Users/ryangreenberg/workspace/node-temp/lib/temp.js:62:3
    at Object.openSync (/Users/ryangreenberg/workspace/node-temp/lib/temp.js:125:3)
    at Object.<anonymous> (/Users/ryangreenberg/workspace/node-temp/test/temp-test.js:45:8)
    at Module._compile (module.js:432:26)
    at Object..js (module.js:450:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
```

The advantage of bermi's fix is that it's shorter.

A couple advantages of the attached diff:
- a listener to process exit is only created when temp files are created (as opposed to unconditionally when you require the module)
- named functions may make it more explicit what is happening for someone reading the code
- includes a test that ensures that a single listener is used for all exit events. 
- you could expose deleteAllTempFiles in exports if people wanted an interface to deleting all temp files before process exit.

I didn't change the version number, so please change it if you accept this request. Thanks!
