### PR TITLE
use path.resolve instead of path.join with prefix

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -19,7 +19,7 @@ var generateName = function(rawAffixes, defaultPrefix) {
               '-',
               (Math.random() * 0x100000000 + 1).toString(36),
               affixes.suffix].join('');
-  return path.join(exports.dir, name);
+  return path.resolve(exports.dir, name);
 }
 
 var parseAffixes = function(rawAffixes, defaultPrefix) {


### PR DESCRIPTION
Now you can set base directory for temp files without modifying exports.dir on per call basis:

``` js
var tmp = temp.path({
  prefix: '/mydir'
});
console.log(tmp);
```

Output:

> /mydir/11318-1165-cahfb7

This is backward compatible (just don't use leading slash in prefix:

``` js
var tmp = temp.path({
  prefix: 'myfile'
});
console.log(tmp);
```

Output:

> /tmp/myfile11318-1165-cahfb7
