### PR TITLE
Adding var declarations to prevent memory leaks (minor)

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -116,8 +116,8 @@ var cleanupDirs = function() {
 
 var cleanup = function() {
   if (!tracking) return false;
-  fileCount = cleanupFiles();
-  dirCount  = cleanupDirs();
+  var fileCount = cleanupFiles();
+  var dirCount  = cleanupDirs();
   return {files: fileCount, dirs: dirCount};
 }
 


### PR DESCRIPTION
Hello Bruce, 

Really a minor thing, but I have noticed these two vars are leaking into the global context. It's not killer, not anyhow major, but it was failing our testing setup with mocha, which by default inspects its test for memory leaks. 

That was corrected for me, so if you think it's worth it - please include it into mainstream.

Best regards, 
Alex. 
