### PR TITLE
Make track() chainable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ temp.open('myprefix', function(err, info) {
 
 As noted in the example above, if you want temp to track the files and directories
 it creates and handle removing those files and directories on exit, you must call `track()`.
-It's recommended that you do this immediately after requiring the module.
+The `track()` function is chainable, and it's recommended that you call it
+when requiring the module.
 
 ```javascript
-var temp = require("temp");
-temp.track();
+var temp = require("temp").track();
 ```
 
 Why is this necessary? In pre-0.6 versions of temp, tracking was automatic. While this works

--- a/lib/temp.js
+++ b/lib/temp.js
@@ -50,7 +50,8 @@ var parseAffixes = function(rawAffixes, defaultPrefix) {
  */
 var tracking = false;
 var track = function(value) {
-  tracking = (value != false)
+  tracking = (value != false);
+  return module.exports; // chainable
 };
 var exitListenerAttached = false;
 var filesToDelete = [];


### PR DESCRIPTION
This way you can write

```
var temp = require('temp').track();
```
