### PR TITLE
Throw real error instead of a string

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -34,7 +34,7 @@ var parseAffixes = function(rawAffixes, defaultPrefix) {
       affixes = rawAffixes;
       break;
     default:
-      throw("Unknown affix declaration: " + affixes);
+      throw new Error("Unknown affix declaration: " + affixes);
     }
   } else {
     affixes.prefix = defaultPrefix;


### PR DESCRIPTION
Fixes an issue where mocha tests don't catch errors properly. To repro with mocha:

```
it('should throw an error', function (done) {
  temp.open(function nothing () {}, function (err, file) {
    expect(err).to.exist;
    done();
  }
});
```

Gives:
`Error: the string "Unknown affix declaration: [object Object]" was thrown, throw an Error :)`
in the test output
