### PR TITLE
use `os.tmpdir()` polyfill for more consistent behaviour

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -1,9 +1,9 @@
 var fs   = require('fs'),
-    os   = require('os'),
     path = require('path'),
     cnst = require('constants');
 
 var rimraf     = require('rimraf'),
+    osTmpdir   = require('os-tmpdir'),
     rimrafSync = rimraf.sync;
 
 /* HELPERS */
@@ -270,7 +270,7 @@ function createWriteStream(affixes) {
 
 /* EXPORTS */
 // Settings
-exports.dir               = path.resolve(os.tmpDir());
+exports.dir               = path.resolve(osTmpdir());
 exports.track             = track;
 // Functions
 exports.mkdir             = mkdir;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "./lib/temp",
   "dependencies": {
+    "os-tmpdir": "^1.0.0",
     "rimraf": "~2.2.6"
   },
   "keywords": [


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions and it would be nice for users if it were consistent between Node versions. This might even prevent hard to track down bugs.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.2: https://github.com/nodejs/io.js/blob/c7fb91dc1310f9454d4aa8091bcc6d305322a72f/lib/os.js#L25-L43

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform

> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir