### PR TITLE
Add license metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "version": "0.8.1",
   "author": "Bruce Williams <brwcodes@gmail.com>",
+  "license": "MIT",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
Hello, and thanks for `node-temp`! This pull request just adds `"license": "MIT"` to `package.json`, so automated tools can detect the license without poking around the files.

Tons of packages depend on `node-temp`, so this is a big help to those who'd otherwise have to manually rummage through `node_modules` to hand-code the license.