### PR TITLE
clarify stream.path property in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ temp.mkdir('pdfcreator', function(err, dirPath) {
 
 To create a temporary WriteStream, use 'createWriteStream', which sits
 on top of `fs.createWriteStream`. The return value is a
-`fs.WriteStream` whose `path` is registered for removal when
+`fs.WriteStream` with a `path` property containing the temporary file
+path for the stream. The `path` is registered for removal when
 `temp.cleanup` is called (because `temp.track()` is called).
 
 ```javascript
@@ -179,6 +180,7 @@ var temp = require('temp');
 temp.track();
 
 var stream = temp.createWriteStream();
+// stream.path contains the temporary file path for the stream
 stream.write("Some data");
 // Maybe do some other things
 stream.end();


### PR DESCRIPTION
At first reading, I wasn't sure how to get the path from the createWriteStream. I didn't realize that path was actually a property on stream until after I reviewed the tests. I figured it would be good to clarify this in the doc and example for future users.

Add a additional clarification in doc that createWriteStream returns a
stream with a path property that contains the path to the temporary
file created.

Add stream.path comment in example.
