### PR TITLE
Add support for changing the file's mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Here are some examples:
   within a new temporary directory.
 * `null`: Use the defaults for files and directories (prefixes `"f-"`
   and `"d-"`, respectively, no suffixes).
+* `{mode: 0600}`: The mode of the file to be created.
 
 In this simple example we read a `pdf`, write it to a temporary file with
 a `.pdf` extension, and close it.

--- a/lib/temp.js
+++ b/lib/temp.js
@@ -42,6 +42,12 @@ var parseAffixes = function(rawAffixes, defaultPrefix) {
   return affixes;
 };
 
+var getMode = function(rawAffixes) {
+  if ((rawAffixes == null) || (rawAffixes.mode == null)) {
+    return 0600;
+  }
+  return parseInt(rawAffixes.mode) || 0600;
+}
 /* -------------------------------------------------------------------------
  * Don't forget to call track() if you want file tracking and exit handlers!
  * -------------------------------------------------------------------------
@@ -244,7 +250,7 @@ function mkdirSync(affixes) {
 
 function open(affixes, callback) {
   var filePath = generateName(affixes, 'f-');
-  fs.open(filePath, RDWR_EXCL, 0600, function(err, fd) {
+  fs.open(filePath, RDWR_EXCL, getMode(affixes), function(err, fd) {
     if (!err) {
       deleteFileOnExit(filePath);
     }
@@ -256,14 +262,14 @@ function open(affixes, callback) {
 
 function openSync(affixes) {
   var filePath = generateName(affixes, 'f-');
-  var fd = fs.openSync(filePath, RDWR_EXCL, 0600);
+  var fd = fs.openSync(filePath, RDWR_EXCL, getMode(affixes));
   deleteFileOnExit(filePath);
   return {path: filePath, fd: fd};
 }
 
 function createWriteStream(affixes) {
   var filePath = generateName(affixes, 's-');
-  var stream = fs.createWriteStream(filePath, {flags: RDWR_EXCL, mode: 0600});
+  var stream = fs.createWriteStream(filePath, {flags: RDWR_EXCL, mode: getMode(affixes)});
   deleteFileOnExit(filePath);
   return stream;
 }


### PR DESCRIPTION
Running as root, I needed the ability to make a temp file available to non-root users.  
This patch adds a `mode` affix that sets the permissions of the file to whatever
the caller wants.  The default is still 0600, so there is no change in interface.
