### PR TITLE
Removing os-tmpdir dependency (& support Node 7+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and supports automatic removal (if asked)
 Node.js Compatibility
 ---------------------
 
-Supports v0.10.0+.
+Supports v4.0.0+.
 
 [![Build Status](https://travis-ci.org/bruce/node-temp.png)](https://travis-ci.org/bruce/node-temp)
 
@@ -200,7 +200,7 @@ Here are some examples:
   (especially useful when the file needs to be named with specific
   extension for use with an external program).
 * `{prefix: "myprefix", suffix: "mysuffix"}`: Customize both affixes
-* `{dir: path.join(os.tmpDir(), "myapp")}`: default prefix and suffix
+* `{dir: path.join(os.tmpdir(), "myapp")}`: default prefix and suffix
   within a new temporary directory.
 * `null`: Use the defaults for files and directories (prefixes `"f-"`
   and `"d-"`, respectively, no suffixes).

--- a/lib/temp.js
+++ b/lib/temp.js
@@ -3,7 +3,7 @@ var fs   = require('fs'),
     cnst = require('constants');
 
 var rimraf     = require('rimraf'),
-    osTmpdir   = require('os-tmpdir'),
+    os         = require('os'),
     rimrafSync = rimraf.sync;
 
 /* HELPERS */
@@ -270,7 +270,7 @@ function createWriteStream(affixes) {
 
 /* EXPORTS */
 // Settings
-exports.dir               = path.resolve(osTmpdir());
+exports.dir               = path.resolve(os.tmpdir());
 exports.track             = track;
 // Functions
 exports.mkdir             = mkdir;

--- a/package.json
+++ b/package.json
@@ -17,11 +17,10 @@
     "lib": "lib"
   },
   "engines": [
-    "node >=0.8.0"
+    "node >=4.0.0"
   ],
   "main": "./lib/temp",
   "dependencies": {
-    "os-tmpdir": "^1.0.0",
     "rimraf": "~2.2.6"
   },
   "keywords": [


### PR DESCRIPTION
[os-tmpdir](https://github.com/sindresorhus/os-tmpdir) is deprecated (and shows a warning to Node 7+ users). It's suggested to use `require('os').tmpdir()` instead. This will work consistently from Node 4+.

So that's what I've done here as well as updating the docs and package.json to say Node 4+ is supported.