### PR TITLE
Update rimraf to ~2.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/temp",
   "dependencies": {
     "os-tmpdir": "^1.0.0",
-    "rimraf": "~2.2.6"
+    "rimraf": "~2.6.2"
   },
   "keywords": [
     "temporary",


### PR DESCRIPTION
We're seeing some process crashes using node-temp on Windows (x-ref https://github.com/atom/tree-view/issues/1203). Updating to the latest rimraf seems to fix the issue. This PR updates rimraf to `~2.6.2`, the current latest release.