### PR TITLE
Replaces #49.  Rebased on master, with a couple of tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Here are some examples:
   within a new temporary directory.
 * `null`: Use the defaults for files and directories (prefixes `"f-"`
   and `"d-"`, respectively, no suffixes).
+* `{mode: 0600}`: The mode of the file or directory to be created.
 
 In this simple example we read a `pdf`, write it to a temporary file with
 a `.pdf` extension, and close it.

--- a/lib/temp.js
+++ b/lib/temp.js
@@ -42,6 +42,20 @@ var parseAffixes = function(rawAffixes, defaultPrefix) {
   return affixes;
 };
 
+var getMode = function(rawAffixes, defaultMode) {
+  if ((rawAffixes == null) || (rawAffixes.mode == null)) {
+    return parseInt(defaultMode, 8);
+  }
+  var mode = rawAffixes.mode
+  if (typeof(rawAffixes.mode) !== 'number') {
+    mode = parseInt(mode, 8)
+  }
+  if (isNaN(mode)) {
+    mode = parseInt(defaultMode, 8)
+  }
+  return mode
+};
+
 /* -------------------------------------------------------------------------
  * Don't forget to call track() if you want file tracking and exit handlers!
  * -------------------------------------------------------------------------
@@ -223,7 +237,8 @@ function cleanup(callback) {
 
 function mkdir(affixes, callback) {
   var dirPath = generateName(affixes, 'd-');
-  fs.mkdir(dirPath, parseInt('0700', 8), function(err) {
+  var dirMode = getMode(affixes, '0700');
+  fs.mkdir(dirPath, dirMode, function(err) {
     if (!err) {
       deleteDirOnExit(dirPath);
     }
@@ -235,7 +250,8 @@ function mkdir(affixes, callback) {
 
 function mkdirSync(affixes) {
   var dirPath = generateName(affixes, 'd-');
-  fs.mkdirSync(dirPath, parseInt('0700', 8));
+  var dirMode = getMode(affixes, '0700');
+  fs.mkdirSync(dirPath, dirMode);
   deleteDirOnExit(dirPath);
   return dirPath;
 }
@@ -244,7 +260,8 @@ function mkdirSync(affixes) {
 
 function open(affixes, callback) {
   var filePath = generateName(affixes, 'f-');
-  fs.open(filePath, RDWR_EXCL, parseInt('0600', 8), function(err, fd) {
+  var fileMode = getMode(affixes, '0600');
+  fs.open(filePath, RDWR_EXCL, fileMode, function(err, fd) {
     if (!err) {
       deleteFileOnExit(filePath);
     }
@@ -256,14 +273,16 @@ function open(affixes, callback) {
 
 function openSync(affixes) {
   var filePath = generateName(affixes, 'f-');
-  var fd = fs.openSync(filePath, RDWR_EXCL, parseInt('0600', 8));
+  var fileMode = getMode(affixes, '0600');
+  var fd = fs.openSync(filePath, RDWR_EXCL, fileMode);
   deleteFileOnExit(filePath);
   return {path: filePath, fd: fd};
 }
 
 function createWriteStream(affixes) {
   var filePath = generateName(affixes, 's-');
-  var stream = fs.createWriteStream(filePath, {flags: RDWR_EXCL, mode: parseInt('0600', 8)});
+  var fileMode = getMode(affixes, '0600');
+  var stream = fs.createWriteStream(filePath, {flags: RDWR_EXCL, mode: fileMode});
   deleteFileOnExit(filePath);
   return stream;
 }


### PR DESCRIPTION
I'm happy to change this to throw errors instead of silently fall back to the default, if desired.